### PR TITLE
include missing 1+z term in tutorial scripts for the flux density

### DIFF
--- a/prospector_nonpara_SHFs/psb_sfh_run_prosp.py
+++ b/prospector_nonpara_SHFs/psb_sfh_run_prosp.py
@@ -144,6 +144,7 @@ def build_obs(pd_dir,**kwargs):
     flux = np.asarray(flux)*u.erg/u.s
     dl = cosmo.luminosity_distance(7.2).to('cm')
     flux /= (4.*3.14*dl**2.)
+    flux *=(1+7.2)
     nu = constants.c.cgs/(wav.to(u.cm))
     nu = nu.to(u.Hz)
     flux /= nu

--- a/prospector_nonpara_SHFs/rising_sfh_run_prosp.py
+++ b/prospector_nonpara_SHFs/rising_sfh_run_prosp.py
@@ -124,6 +124,7 @@ def build_obs(pd_dir,**kwargs):
     flux = np.asarray(flux)*u.erg/u.s
     dl = cosmo.luminosity_distance(7.2).to('cm')
     flux /= (4.*3.14*dl**2.)
+    flux *= (1+7.2)
     nu = constants.c.cgs/(wav.to(u.cm))
     nu = nu.to(u.Hz)
     flux /= nu

--- a/run_prosp_nonparaSFH.py
+++ b/run_prosp_nonparaSFH.py
@@ -133,7 +133,7 @@ def build_obs(pd_dir, **kwargs):
     wav = wav.to(u.AA)
     lum = np.asarray(lum)*u.erg/u.s
     dl = (10*u.pc).to(u.cm) #setting luminosity distance to 10pc since we're at z=0
-    flux = lum/(4.*3.14*dl**2.)
+    flux = lum/(4.*3.14*dl**2.) #*(1+z) this is where you would scale the flux density by 1+z
     nu = constants.c.cgs/(wav.to(u.cm))
     nu = nu.to(u.Hz)
     flux /= nu

--- a/run_prosp_paraSFH.py
+++ b/run_prosp_paraSFH.py
@@ -97,7 +97,7 @@ def build_obs(pd_dir, **kwargs):
     wav = wav.to(u.AA)
     lum = np.asarray(lum)*u.erg/u.s
     dl = (10*u.pc).to(u.cm) #setting luminosity distance to 10pc since we're at z=0
-    flux = lum/(4.*3.14*dl**2.)
+    flux = lum/(4.*3.14*dl**2.) #*(1+z) this is where you would scale the flux by 1+z
     nu = constants.c.cgs/(wav.to(u.cm))
     nu = nu.to(u.Hz)
     flux /= nu

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -306,7 +306,7 @@
     "    wav = wav.to(u.AA)\n",
     "    lum = np.asarray(lum)*u.erg/u.s\n",
     "    dl = (10*u.pc).to(u.cm) #setting luminosity distance to 10pc since we're at z=0\n",
-    "    flux = lum/(4.*3.14*dl**2.)\n",
+    "    flux = lum/(4.*3.14*dl**2.) #*(1+z) this is where you would include the 1+z term for the flux\n",
     "    nu = constants.c.cgs/(wav.to(u.cm))\n",
     "    nu = nu.to(u.Hz)\n",
     "    flux /= nu\n",


### PR DESCRIPTION
Add in missing (1+z) term and references to it where appropriate in prosp run scripts. This comes from e.g. equation 6 in [this paper](https://arxiv.org/pdf/astro-ph/0210394) where because maggies/Jy are flux density (i.e. per frequency) units, not just bolometric flux, there also needs to be a multiplicative term of 1+z in addition to the luminosity distance calculation when converting rest-frame powderday SEDs to 'observed' spectra.